### PR TITLE
Game Introduction Animation

### DIFF
--- a/Scroggle/Common/Common.swift
+++ b/Scroggle/Common/Common.swift
@@ -9,3 +9,15 @@
 import Foundation
 
 typealias GenericBlock = () -> Void
+
+
+/// Tells us if we're running on a simulator or not.
+struct Platform {
+    static let isSimulator: Bool = {
+        var isSim = false
+        #if arch(i386) || arch(x86_64)
+        isSim = true
+        #endif
+        return isSim
+    }()
+}

--- a/Scroggle/Common/Extensions/Notification+Scroggle.swift
+++ b/Scroggle/Common/Extensions/Notification+Scroggle.swift
@@ -20,10 +20,12 @@ extension Notification {
         /// - wordGuessed: a word was guessed
         /// - scoreUpdated: the score was updated
         /// - gameEnded: the game has ended
+        /// - beginTimer: the intro animation has completed, start the timer!
         enum GameEvent: String, Notifiable, CustomStringConvertible {
             case wordGuessed  = "word.guessed"
             case scoreUpdated = "score.updated"
             case gameEnded = "ended"
+            case beginTimer = "begin.timer"
 
             static var notificationBase: String {
                 return "scroggle.game"

--- a/Scroggle/Common/Models/Die.swift
+++ b/Scroggle/Common/Models/Die.swift
@@ -17,6 +17,9 @@ class Die: CustomDebugStringConvertible {
         static let sides = "sides"
     }
 
+    /// The ID of this die (for uniqueness)
+    var id: Int
+
     /// The array of sides of the die (array of 6)
     var sides: [String]
 
@@ -28,13 +31,15 @@ class Die: CustomDebugStringConvertible {
         return sides[selectedSide]
     }
 
-    init(sides: [String]) {
+    init(sides: [String], id: Int) {
         self.sides = sides
+        self.id = id
         selectedSide = 6.random
     }
 
-    init(sides: [String], roll: String) {
+    init(sides: [String], id: Int, roll: String) {
         self.sides = sides
+        self.id = id
         selectedSide = sides.index(of: roll) ?? 0
     }
 
@@ -81,11 +86,11 @@ extension Die {
     ///
     /// - Parameter map: The Map that contains the roll and sides of the die.
     /// - Returns: A Die if it was properly deserialized, nil otherwise.
-    static func fromMap(_ map: [String: Any]) -> Die? {
-        if let roll = map[Keys.roll] as? String, let sides = map[Keys.sides] as? [String] {
-            return Die(sides: sides, roll: roll)
+    static func fromMap(_ map: [String: Any], withIndex index: Int) -> Die? {
+        guard let roll = map[Keys.roll] as? String, let sides = map[Keys.sides] as? [String] else {
+            return nil
         }
 
-        return nil
+        return Die(sides: sides, id: index, roll: roll)
     }
 }

--- a/Scroggle/Common/Models/GameBoard.swift
+++ b/Scroggle/Common/Models/GameBoard.swift
@@ -14,9 +14,30 @@ class GameBoard {
 
     init(dice: [[String]]) {
         board = []
+        var index = 0
         for sides in dice {
-            board.append(Die(sides: sides))
+            board.append(Die(sides: sides, id: index))
+            index += 1
         }
+    }
+
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension GameBoard: CustomDebugStringConvertible {
+
+    var debugDescription: String {
+        var result = "Dice:\n"
+        for die in board {
+            result += "\(die.sides)\n"
+        }
+
+        // Now print the board
+        result += "\nBoard:\n"
+        result += configuration
+
+        return result
     }
 
 }
@@ -26,9 +47,7 @@ class GameBoard {
 extension GameBoard {
 
     /// Builds you a string that represents the configuration of the board.
-    ///
-    /// - Returns: The current rolled configuration of the board.
-    func getConfiguration() -> String {
+    var configuration: String {
         let size = Int(sqrt(Double(board.count)))
         var result = ""
 
@@ -141,11 +160,13 @@ extension GameBoard {
     /// - Returns: A GameBoard with the deserialized configuration
     static func fromArray(_ array: [Any]) -> GameBoard {
         let board = GameBoard(dice: [])
+        var index = 0
         for dieMap in array {
-            guard let map = dieMap as? [String: Any], let die = Die.fromMap(map) else {
+            guard let map = dieMap as? [String: Any], let die = Die.fromMap(map, withIndex: index) else {
                 continue
             }
             board.board.append(die)
+            index += 1
         }
         return board
     }

--- a/Scroggle/Common/Services/DiceProvider.swift
+++ b/Scroggle/Common/Services/DiceProvider.swift
@@ -8,8 +8,6 @@
 
 import UIKit
 
-// TODO: extract a protocol (DiceService) from DiceProvider
-
 /// A Provider that will generate you GameBoards.
 ///
 /// **Note:** To generate GameBoards, we depend on the `dice.json` file living in the main bundle
@@ -64,7 +62,7 @@ extension DiceProvider {
     /// - Parameter board: The board to check for vowels.
     /// - Returns: True if it has at least 3 vowels
     func hasEnoughVowels(_ board: GameBoard) -> Bool {
-        return board.board.map({ vowels.contains($0.roll) }).filter({$0}).count > 3
+        return board.board.map({ vowels.contains($0.roll) }).filter({ $0 }).count > 3
     }
 
     /// Loads the dice.json file and populates the data structures from it.

--- a/Scroggle/Gameplay/HUDViewController.swift
+++ b/Scroggle/Gameplay/HUDViewController.swift
@@ -36,10 +36,8 @@ class HUDViewController: UIViewController {
 
         Notification.Scroggle.GameEvent.scoreUpdated.addObserver(self, selector: #selector(scoreUpdated(_:)))
         Notification.Scroggle.GameEvent.gameEnded.addObserver(self, selector: #selector(gameEnded))
+        Notification.Scroggle.GameEvent.beginTimer.addObserver(self, selector: #selector(beginTimer(_:)))
 
-        // TODO: Delay this after an "introduction animation":
-        timer = Timer.scheduledTimer(timeInterval: 1, target: self,
-                                     selector: #selector(updateTimer), userInfo: nil, repeats: true)
     }
 
     override func willTransition(to newCollection: UITraitCollection,
@@ -72,6 +70,12 @@ class HUDViewController: UIViewController {
 // MARK: - Events
 
 extension HUDViewController {
+
+    @objc
+    func beginTimer(_ notification: NSNotification) {
+        timer = Timer.scheduledTimer(timeInterval: 1, target: self,
+                                     selector: #selector(updateTimer), userInfo: nil, repeats: true)
+    }
 
     @objc
     /// Responds to the time updated event

--- a/Scroggle/Gameplay/Nodes/GameSceneController+Animations.swift
+++ b/Scroggle/Gameplay/Nodes/GameSceneController+Animations.swift
@@ -48,6 +48,8 @@ extension GameSceneController {
         }
     }
 
+    /// Sets the euler angles to the intended positions for each die, so that the
+    /// side that was rolled to becomes the visible side.
     func setEulerAnglesForDice() {
         guard let diceArray = GameContextProvider.instance.currentGame?.game.board.board else {
             return assertionFailure("Failed to get the dice")
@@ -65,16 +67,23 @@ extension GameSceneController {
         dice.forEach { [weak self] die in
             self?.randomlyMove(die: die) {
                 results += 1
-                if results == count {
-                    completion?()
+
+                guard results == count else {
+                    // only call back when the last die has finished moving
+                    return
                 }
+                completion?()
             }
         }
     }
 
-    /// Rotates the provided die to a random side
+    /// This is a 2 step random process:
+    /// 1. Randomly rotate the die and move it to a random position (above the board)
+    /// 2. At the apex, move it back to its original location, but with to a random side
     ///
-    /// - Parameter die: The die to be moved
+    /// - Parameters:
+    ///   - die: The die to be moved
+    ///   - completion: The callback to tell you that the animation has completed
     func randomlyMove(die: SCNNode, completion: GenericBlock? = nil) {
         let originalPosition = die.position
         let randomEuler = eulerAngle(for: 5.random)
@@ -103,7 +112,9 @@ extension GameSceneController {
 
     /// Rolls the die at the provided index.
     ///
-    /// - Parameter index: The index of the die you want to roll
+    /// - Parameters:
+    ///   - index: The index of the die you want to roll
+    ///   - completion: The callback to tell you that the random roll has completed
     func rollRandom(at index: Int, completion: GenericBlock? = nil) {
         guard index < dice.count else {
             return
@@ -118,7 +129,6 @@ extension GameSceneController {
         let randomX = Float(6.random) - 3
         let randomY = Float(6.random) - 3
         let randomZ = Float(25.random) + 5
-//        DLog("Random Position: \(Int(randomX)), \(Int(randomY)), \(Int(randomZ))")
 
         let randomAngleX = CGFloat(360.random.radians)
         let randomAngleY = CGFloat(360.random.radians)

--- a/Scroggle/Gameplay/Nodes/GameSceneController.swift
+++ b/Scroggle/Gameplay/Nodes/GameSceneController.swift
@@ -90,6 +90,8 @@ extension GameSceneController {
         addClickableTiles()
 
         guard !Platform.isSimulator else {
+            // If we're running in the simulator, just set the intended Euler Angles,
+            // skip the intro (roll dice) animation and start the game
             setEulerAnglesForDice()
             Notification.Scroggle.GameEvent.beginTimer.notify()
             return

--- a/Scroggle/Gameplay/Nodes/GameSceneController.swift
+++ b/Scroggle/Gameplay/Nodes/GameSceneController.swift
@@ -28,6 +28,9 @@ class GameSceneController {
     /// The SCNNodes for the dice (there should be 16 of them in a 4x4 board)
     var dice: [SCNNode] = []
 
+    /// The positions for each die
+    var dicePositions = [SCNVector3]()
+
     /// The Clickable Tiles (laid over the dice)
     var tiles: [SKShapeNode] = []
 
@@ -84,19 +87,38 @@ extension GameSceneController {
         readDiceReferences()
         readCameraReference()
         setDiceMaterial()
-        // TODO: Reenable the rollDice function
-//        rollDice()
         addClickableTiles()
+
+        guard !Platform.isSimulator else {
+            setEulerAnglesForDice()
+            Notification.Scroggle.GameEvent.beginTimer.notify()
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            guard let self = self else {
+                return
+            }
+            if let rootNode = self.gameScene?.rootNode {
+                SoundProvider.instance.playDiceRollSound(node: rootNode)
+            }
+            self.rollDice {
+                Notification.Scroggle.GameEvent.beginTimer.notify()
+            }
+        }
     }
 
     /// Reads the dice nodes from the scene and stores them in the `dice` array.
     func readDiceReferences() {
         dice.removeAll()
+        dicePositions.removeAll()
+
         for index in 0..<16 {
-            guard let die = gameScene?.rootNode.childNodes.filter({$0.name == "d\(index)"}).first else {
+            guard let die = getDie(at: index) else {
                 continue
             }
             dice.append(die)
+            dicePositions.append(die.position)
         }
         assert(dice.count == 16)
     }
@@ -123,7 +145,8 @@ extension GameSceneController {
                 continue
             }
             box.materials = diceArray[index].sides.map({self.createMaterialForText(text: $0)})
-            dice[index].eulerAngles = eulerAngle(for: diceArray[index].selectedSide)
+            // Let the intro animation do this part
+//            dice[index].eulerAngles = eulerAngle(for: diceArray[index].selectedSide)
         }
     }
 


### PR DESCRIPTION
### Background
When a game starts, the game board should have a pleasant dice rolling animation, along with a dice rolling sound (if sound is on and loud enough).  This animation *should not* run in the simulator since this is graphics intensive and makes the simulator nearly unusable.

### Features Implemented
- Game introduction (dice roll) animation
- Dice rolling sound during the "dice rolling animation"

### Checklist
- [x] Appropriate label has been added to this PR (i.e., Bug, Feature, Under Construction, etc.).
- [x] Documentation has been added to all `open`, `public`, and `internal` scoped methods and properties.
- [x] N/A ~Tests have have been added to all new features.~
- [x] Image/GIFs have been added for all UI related changed.

### Screenshots

![intro-animation](https://user-images.githubusercontent.com/2284832/46917825-69a93980-cf88-11e8-9017-e296e53eb4f5.gif)
